### PR TITLE
Updated readme with correct docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can also setup the dev env using docker
 
 ```
 docker pull worldbrain/cortex
-docker run -it --net=host --name=cortex cortex_docker
+docker run -it --net=host --name=cortex worldbrain/cortex
 ```
 
 Happy hacking!


### PR DESCRIPTION
Earlier it was cortex_docker which I named for my local testing but it was worldbrain/cortex which is the actual docker repo name