### PR TITLE
Add socket timeout for feedspider

### DIFF
--- a/worldbrain/cortex/management/commands/feedspider.py
+++ b/worldbrain/cortex/management/commands/feedspider.py
@@ -11,7 +11,7 @@ from worldbrain.cortex.models import Source, SourceStates
 class Command(BaseCommand):
     credentials = pika.PlainCredentials('worldbrain', 'worldbrain')
     parameters = pika.ConnectionParameters('polisky.me', 5672, '/worldbrain',
-                                           credentials)
+                                           credentials, socket_timeout=2)
 
     def __init__(self, queue='worldbrain-spider'):
         self.SPIDER_QUEUE = queue


### PR DESCRIPTION
One very small but important addition: socket timeout in _feedspider_. Otherwise broken connections with _RabbitMQ_ can occur.